### PR TITLE
Fix print_flushed statement TypeError

### DIFF
--- a/pymapconv.py
+++ b/pymapconv.py
@@ -15,8 +15,8 @@ import gc
 
 pymapconv_version = "3.9"
 
-def print_flushed(message, args=""):
-	print (message, args)
+def print_flushed(*args):
+	print ' '.join(str(x) for x in args)
 	sys.stdout.flush()
 
 


### PR DESCRIPTION
When decompiling a map, there are a number of calls to `print_flushed` that have more than 2 arguments (here's one example: https://github.com/Beherith/springrts_smf_compiler/blob/master/pymapconv.py#L887), which cause the below crash:

```
('Welcome to the SMF compiler/decompiler by Beherith (mysterme@gmail.com) 3.9', '')
(Namespace(decompile='F:/Games/Beyond-All-Reason/data/maps/Testmap_v1.sdd/maps/Testmap_v1.smf', dirty=False, featurelist=None, featuremap=None, featureplacement=None, geoventfile='geovent.bmp', grassmap=None, heightmap='', highresheightmapfilter='nearest', intex='', linux=False, maxheight=100.0, metalmap=None, minheight=-50.0, minimap=None, nvdxt_options='-Sinc -quality_highest', outfile='my_new_map.smf', skiptexture=False, typemap=None), '')
(('spring map file\x00', 1, 351, 1536, 3072, 8, 8, 32, -150.0, 850.0, 295004, 9741406, 12799750, 10921054, 11620102, 13979423, 1), '')
('Writing minimap', '')
('Writing heightmap PNG', '')
('Writing MetalMap', '')
('Writing typemap', '')
('Writing grassmap', '')
Traceback (most recent call last):
  File "argparseui.py", line 664, in onOk
    self.ok_button_handler(self)
  File "pymapconv.py", line 1103, in okbuttonhandler
    if parsed_args.decompile != '' and parsed_args.decompile != None:
  File "pymapconv.py", line 887, in __init__
    print_flushed ('Extraheader:', extraheader, '(size, type, extraoffset)')
TypeError: print_flushed() takes at most 2 arguments (3 given)
```

I've updated the `print_flushed` function to take any number of arguments, similar to the normal print statement in python. This changes the output text so that not everything printed to stdout is wrapped in tuples, see below for what that looks like. This may break programs for anyone that parses the stdout from this program (heads up to @adras who last changed stdout formatting in https://github.com/Beherith/springrts_smf_compiler/pull/18).

```
Welcome to the SMF compiler/decompiler by Beherith (mysterme@gmail.com) 3.9
Namespace(decompile='F:/Games/Beyond-All-Reason/data/maps/Testmap_v1.sdd/maps/Testmap_v1.smf', dirty=False, featurelist=None, featuremap=None, featureplacement=None, geoventfile='geovent.bmp', grassmap=None, heightmap='', highresheightmapfilter='nearest', intex='', linux=False, maxheight=100.0, metalmap=None, minheight=-50.0, minimap=None, nvdxt_options='-Sinc -quality_highest', outfile='my_new_map.smf', skiptexture=False, typemap=None)
('spring map file\x00', 1, 351, 1536, 3072, 8, 8, 32, -150.0, 850.0, 295004, 9741406, 12799750, 10921054, 11620102, 13979423, 1)
Writing minimap
Writing heightmap PNG
Writing MetalMap
Writing typemap
Writing grassmap
Extraheader: (12, 1, 92) (size, type, extraoffset)
Map seems to have new style 0-254 awesome grass 211
MapFeatureHeader= (17, 0) (numFeatureType, numFeatures)
MapTileHeader= (1, 294912) (numTileFiles, numTiles)
TreeType0
TreeType1
TreeType2
TreeType3
TreeType4
TreeType5
TreeType6
TreeType7
TreeType8
TreeType9
TreeType10
TreeType11
TreeType12
TreeType13
TreeType14
TreeType15
GeoVent
Features found in map definition ['TreeType0', 'TreeType1', 'TreeType2', 'TreeType3', 'TreeType4', 'TreeType5', 'TreeType6', 'TreeType7', 'TreeType8', 'TreeType9', 'TreeType10', 'TreeType11', 'TreeType12', 'TreeType13', 'TreeType14', 'TreeType15', 'GeoVent']
Writing feature placement file
loading tile files
Test_map.smt has 294912 tiles
Generating texture, this is very very slow (few minutes)
Done, one final bit of important info: the maps maxheight is 850, while the minheight is -150
```